### PR TITLE
eulerXYZ to quaternion changed

### DIFF
--- a/src/vicon_bridge_udp.cpp
+++ b/src/vicon_bridge_udp.cpp
@@ -84,7 +84,7 @@ void Client::receiveTransforms(std::vector<geometry_msgs::TransformStamped> &dat
             data[i].transform.translation.y = object->ty * 1e-3;
             data[i].transform.translation.z = object->tz * 1e-3;
             tf2::Quaternion myQuaternion;
-            myQuaternion.setRPY(object->ry, -object->rx, object->rz);
+            myQuaternion.setRPY(object->rx, object->ry, object->rz);
             data[i].transform.rotation.x = myQuaternion.x();
             data[i].transform.rotation.y = myQuaternion.y();
             data[i].transform.rotation.z = myQuaternion.z();


### PR DESCRIPTION
RPY to Quaternion conversion is changed so that it is compatible with the default VICON orientation.